### PR TITLE
Feat/backend/save data

### DIFF
--- a/backend/api/service/memoryStore.go
+++ b/backend/api/service/memoryStore.go
@@ -2,7 +2,9 @@ package service
 
 import (
 	"backend/domain/model"
+	"fmt"
 	"sync"
+	"time"
 )
 
 // Thread-safe in-memory store
@@ -23,6 +25,19 @@ func (s *ThreadSafeMemoryStore) SaveMessage(username string, message model.Messa
 	s.Lock()
 	defer s.Unlock()
 
+	// Parse the existing timestamp in message to time.Time
+	timestamp, err := time.Parse(time.RFC3339, message.Timestamp)
+	if err != nil {
+		// Handle error if the timestamp is not in RFC3339 format
+		// This error handling is important to avoid storing incorrect data
+		fmt.Println("Error parsing timestamp:", err)
+		return
+	}
+
+	// Format the timestamp to "2006-01-02 15:04:05"
+	message.Timestamp = timestamp.Format("2006-01-02 15:04:05")
+
+	// Save the message with the formatted timestamp
 	s.Messages[username] = append(s.Messages[username], message)
 }
 

--- a/backend/api/service/websocket.go
+++ b/backend/api/service/websocket.go
@@ -40,7 +40,7 @@ func HandleWebSocketConnection(c echo.Context) error {
 			response := model.Response{
 				Username:  msg.Username,
 				Message:  msg.Message,
-				Timestamp: time.Now().Format(time.RFC3339),
+				Timestamp: time.Now().Format("2006-01-02 15:04:05"),
 			}
 
 			// Send response message


### PR DESCRIPTION
## 🔖 チケットへのリンク

-   https://github.com/Tsuyopon-1067/data-programing-last-app/issues/11

## ✨ やったこと

-   受信したメッセージをサーバ側で主記憶上で保存
-   保存したメッセージの一覧をクライアント接続時に送信

## 🔥 やらないこと

-   無し

## 🙆 できるようになること（ユーザ目線）

-   他のユーザが送ったり，過去自分が送ったりしたメッセージを再度接続しても見ることができるようになった

## 🙅 できなくなること（ユーザ目線）

-   無し

## 🚀 動作確認

-   `docker-compose build`が通ることを確認
-   `docker-compose up`が通ることを確認
-   `localhost:8080`に接続して，メッセージを送受信できることを確認

## 👽️ その他

-   
