### PR TITLE
🐛 サーバへのAPIリクエストURL相対パスに修正

### DIFF
--- a/frontend/src/components/organisms/NewsList.tsx
+++ b/frontend/src/components/organisms/NewsList.tsx
@@ -5,9 +5,9 @@ import NewsItem from "../molecules/NewsItem";
 import styles from "./NewsList.module.css";
 
 export const NewsList = () => {
-  const[newsList, setNewsList] = useState<News[]>([]);
+  const [newsList, setNewsList] = useState<News[]>([]);
   useEffect(() => {
-    fetch('http://localhost:8080/fetch/news')
+    fetch('./fetch/news')
       .then(response => {
         if (!response.ok) {
           throw new Error('Network response was not ok');
@@ -48,9 +48,9 @@ export const NewsList = () => {
       </div>
       <NewsItems />
       <a className={styles.a} href="https://news.yahoo.co.jp/">
-      <div className={styles.bottomArea}>
-        <span className={styles.bottomText}>Yahooニュースより</span>
-      </div>
+        <div className={styles.bottomArea}>
+          <span className={styles.bottomText}>Yahooニュースより</span>
+        </div>
       </a>
     </Stack>
   );

--- a/frontend/src/components/organisms/TimeLine.tsx
+++ b/frontend/src/components/organisms/TimeLine.tsx
@@ -11,7 +11,7 @@ export const TimeLine = () => {
   const [pastPostsData, setPastPostsData] = useState<ReceiveMessageType[]>([]);
 
   useEffect(() => {
-    fetch('http://localhost:8080/fetch/username')
+    fetch('./fetch/username')
       .then(response => {
         if (!response.ok) {
           throw new Error('Network response was not ok');


### PR DESCRIPTION
## 🔖 チケットへのリンク

- https://github.com/Tsuyopon-1067/data-programing-last-app/issues/42

## ✨ やったこと

- サーバへのAPIリクエストに使うURLを相対パスにした
    - 以前はlocalhost:8080/になっていたため，本番環境だとAPIリクエストに失敗していた

## 🔥 やらないこと

- 無し

## 🙆 できるようになること（ユーザ目線）

- 本番環境でもニュース閲覧ができ，ユーザ名が自動で割り当てられるようになる

## 🙅 できなくなること（ユーザ目線）

-   無し

## 🚀 動作確認

- dockerで動作確認
- 本番環境では未検証

## 👽️ その他

-  無し