### PR TITLE
🐛  postの履歴順序が乱れる不具合を修正

### DIFF
--- a/frontend/src/components/organisms/TimeLine.tsx
+++ b/frontend/src/components/organisms/TimeLine.tsx
@@ -62,7 +62,7 @@ export const TimeLine = () => {
 
   const PastPosts = () => {
     return (
-      pastPostsData.reverse().map((postData) => (
+      pastPostsData.slice().reverse().map((postData) => (
         <PostItem
           name={postData.username}
           content={postData.message}


### PR DESCRIPTION
## 🔖 チケットへのリンク

- https://github.com/Tsuyopon-1067/data-programing-last-app/issues/41

## ✨ やったこと

- タイムラインに表示されるpost履歴順序がおかしくなる不具合を修正
    - 原因はjavascriptのreverseメソッドを実行したとき配列自体が逆転していたこと

## 🔥 やらないこと

- 無し

## 🙆 できるようになること（ユーザ目線）

- postの表示順が正常になる

## 🙅 できなくなること（ユーザ目線）

-   無し

## 🚀 動作確認

- ブラウザで動作確認

## 👽️ その他

-  無し