### PR TITLE
💄   WordCloudの更新ボタンを追加

### DIFF
--- a/frontend/src/components/atom/RenewButton.tsx
+++ b/frontend/src/components/atom/RenewButton.tsx
@@ -1,0 +1,10 @@
+import { Autorenew } from "@mui/icons-material";
+import { IconButton } from "@mui/material";
+
+export const RenewButton: React.FC<{ onClick: () => void }> = ({ onClick }) => {
+  return (
+    <IconButton onClick={() => onClick()}>
+      <Autorenew />
+    </IconButton>
+  );
+};

--- a/frontend/src/components/atom/WordCloudPic.tsx
+++ b/frontend/src/components/atom/WordCloudPic.tsx
@@ -1,10 +1,14 @@
-import React from 'react';
-import styles from './WordCloudPic.module.css';
+import React from "react";
+import styles from "./WordCloudPic.module.css";
 
-export const WordCloudPic: React.FC<{ finishLoading: () => void }> = ({ finishLoading }) => {
+export const WordCloudPic: React.FC<{
+  finishLoading: () => void;
+  hash: string;
+}> = ({ finishLoading, hash }) => {
   return (
-    <img className={styles.img}
-      src="./fetch/wordcloud"
+    <img
+      className={styles.img}
+      src={`./fetch/wordcloud?${hash}`}
       alt="word cloud image"
       onLoad={() => finishLoading()}
     />

--- a/frontend/src/components/molecules/WordCloudDisplay.tsx
+++ b/frontend/src/components/molecules/WordCloudDisplay.tsx
@@ -2,27 +2,37 @@ import { useState } from "react";
 import styles from "./WordCloudDisplay.module.css";
 import { WordCloudPic } from "../atom/WordCloudPic";
 import { CircularProgress } from "@mui/material";
+import { RenewButton } from "../atom/RenewButton";
 
 export const WordCloudDisplay = () => {
   const [isLoaded, setIsLoaded] = useState(false);
+  const generateRandomString = () => Math.random.toString();
+  const [hash, setHash] = useState(generateRandomString()); // imgタグのsrcに対するクエリパラメータ
   const WordCloudOrCircularProgress = () => {
     return (
       <div>
         <div style={{ display: isLoaded ? "block" : "none" }}>
-          <WordCloudPic finishLoading={() => setIsLoaded(true)} />
+          <WordCloudPic finishLoading={() => setIsLoaded(true)} hash={hash} />
         </div>
         <CircularProgress
           color="inherit"
           style={{ display: isLoaded ? "none" : "block" }}
         />
       </div>
-    )
-
-  }
+    );
+  };
   return (
     <div className={styles.main}>
       <div className={styles.description}>
-        <h2>Word Cloud</h2>
+        <h2>
+          Word Cloud{" "}
+          <RenewButton
+            onClick={() => {
+              setHash(generateRandomString());
+              setIsLoaded(false);
+            }}
+          />
+        </h2>
         <p>全投稿からWord Cloudを生成します．</p>
         <p>表示まで5秒ほどかかる場合があります．</p>
       </div>
@@ -31,4 +41,4 @@ export const WordCloudDisplay = () => {
       </div>
     </div>
   );
-}
+};


### PR DESCRIPTION
## 🔖 チケットへのリンク

- https://github.com/Tsuyopon-1067/data-programing-last-app/issues/75

## ✨ やったこと

-  WordCloudの更新ボタンを追加した

## 🔥 やらないこと

- WordCloud画面に遷移した時の自動更新
    - 重いのでやらない予定

## 🙆 できるようになること（ユーザ目線）

- ボタンでWordCloudを更新できる

## 🙅 できなくなること（ユーザ目線）

-  無し

## 🚀 動作確認

- `docker compose up`してブラウザで動作確認

## 👽️ その他

- 無し
