### PR TITLE
:adhesive_bandage: matplotlibを禁止パッケージに追加

### DIFF
--- a/backend/api/service/checkForbiddenImports.go
+++ b/backend/api/service/checkForbiddenImports.go
@@ -18,6 +18,7 @@ var forbiddenImports = []string{
 	"pickle",
 	"eval",
 	"exec",
+	"matplotlib",
 	// Add more dangerous packages as needed
 }
 


### PR DESCRIPTION
## 🔖 チケットへのリンク

-   #88 

## ✨ やったこと

-   禁止パッケージにmatplotlibを追加

## 🔥 やらないこと

-   無し

## 🙆 できるようになること（ユーザ目線）

-   無し

## 🙅 できなくなること（ユーザ目線）

-   matplotlibパッケージをインポートするコードが実行できなくなる

## 🚀 動作確認

-   してない

## 👽️ その他

-   無し
